### PR TITLE
feat: Add vote extensions

### DIFF
--- a/protocol/Dockerfile
+++ b/protocol/Dockerfile
@@ -41,6 +41,12 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
       -o /dydxprotocol/build/ \
       ./...
 
+# Build the oracle binary
+WORKDIR /
+RUN git clone https://github.com/skip-mev/slinky.git
+WORKDIR /slinky
+RUN make build
+
 # --------------------------------------------------------
 # Runner
 # --------------------------------------------------------
@@ -50,6 +56,8 @@ FROM golang@sha256:${GOLANG_1_21_ALPINE_DIGEST}
 RUN apk add --no-cache bash
 
 COPY --from=builder /dydxprotocol/build/dydxprotocold /bin/dydxprotocold
+COPY --from=builder /slinky/build/oracle /bin/slinky
+COPY --from=builder /slinky/config/local/oracle.toml /etc/oracle.toml
 
 ENV HOME /dydxprotocol
 WORKDIR $HOME

--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -1321,12 +1321,12 @@ func New(
 	}
 	// run prometheus metrics
 	if cfg.MetricsEnabled {
-		logger, err := zap.NewProduction()
+		promLogger, err := zap.NewProduction()
 		if err != nil {
 			panic(err)
 		}
 
-		app.oraclePrometheusServer, err = promserver.NewPrometheusServer(cfg.PrometheusServerAddress, logger)
+		app.oraclePrometheusServer, err = promserver.NewPrometheusServer(cfg.PrometheusServerAddress, promLogger)
 		if err != nil {
 			panic(err)
 		}
@@ -1400,7 +1400,7 @@ func New(
 
 	// Vote Extension setup.
 	voteExtensionsHandler := ve.NewVoteExtensionHandler(
-		app.Logger(),
+		logger,
 		app.oracleClient,
 		time.Second,
 		currencypair.NewDeltaCurrencyPairStrategy(app.PricesKeeper),

--- a/protocol/cmd/dydxprotocold/cmd/config.go
+++ b/protocol/cmd/dydxprotocold/cmd/config.go
@@ -7,6 +7,7 @@ import (
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	oracleconfig "github.com/skip-mev/slinky/oracle/config"
 )
 
 const (
@@ -25,6 +26,7 @@ const (
 // DydxAppConfig specifies dYdX app specific config.
 type DydxAppConfig struct {
 	serverconfig.Config
+	Oracle oracleconfig.AppConfig `mapstructure:"oracle"`
 }
 
 // TODO(DEC-1718): Audit tendermint and app config parameters for mainnet.
@@ -52,6 +54,13 @@ func initAppConfig() (string, *DydxAppConfig) {
 
 	appConfig := DydxAppConfig{
 		Config: *srvCfg,
+		Oracle: oracleconfig.AppConfig{
+			Enabled:                 true,
+			OracleAddress:           "localhost:8080",
+			ClientTimeout:           time.Second * 2,
+			MetricsEnabled:          false,
+			PrometheusServerAddress: "",
+		},
 	}
 
 	// Enable telemetry.
@@ -65,7 +74,7 @@ func initAppConfig() (string, *DydxAppConfig) {
 	// GRPC.
 	appConfig.GRPC.Address = "0.0.0.0:9090"
 
-	appTemplate := serverconfig.DefaultConfigTemplate
+	appTemplate := serverconfig.DefaultConfigTemplate + oracleconfig.DefaultConfigTemplate
 
 	return appTemplate, &appConfig
 }

--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -112,6 +112,18 @@ services:
       - DAEMON_HOME=/dydxprotocol/chain/.dave
     volumes:
       - ./localnet/dydxprotocol3:/dydxprotocol/chain/.dave/data
+  slinky0:
+    image: local:dydxprotocol
+    entrypoint:
+      - slinky
+      - -oracle-config-path
+      - /etc/oracle.toml
+      - -host
+      - "0.0.0.0"
+      - -port
+      - "8080"
+    ports:
+      - "8080:8080"
 
   datadog-agent:
     image: public.ecr.aws/datadog/agent:7

--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/skip-mev/slinky v0.2.1-0.20240205201114-084e56f076aa
 	github.com/spf13/viper v1.18.2
+	go.uber.org/zap v1.26.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20231212172506-995d672761c0
 	google.golang.org/protobuf v1.32.0
 )
@@ -380,7 +381,6 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.tmz.dev/musttag v0.7.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20230307190834-24139beb5833 // indirect
 	golang.org/x/mod v0.14.0 // indirect
@@ -419,8 +419,6 @@ replace (
 	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8
 	// Use dYdX fork of Cosmos SDK
 	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240126201553-f1da3a9865bb
-
-	github.com/skip-mev/slinky => ../../slinky
 )
 
 replace (

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -1346,6 +1346,8 @@ github.com/sivchari/nosnakecase v1.7.0 h1:7QkpWIRMe8x25gckkFd2A5Pi6Ymo0qgr4JrhGt
 github.com/sivchari/nosnakecase v1.7.0/go.mod h1:CwDzrzPea40/GB6uynrNLiorAlgFRvRbFSgJx2Gs+QY=
 github.com/sivchari/tenv v1.7.1 h1:PSpuD4bu6fSmtWMxSGWcvqUUgIn7k3yOJhOIzVWn8Ak=
 github.com/sivchari/tenv v1.7.1/go.mod h1:64yStXKSOxDfX47NlhVwND4dHwfZDdbp2Lyl018Icvg=
+github.com/skip-mev/slinky v0.2.1-0.20240205201114-084e56f076aa h1:19BBqLYZ5d83vVOHHJHY1pD3fbJbdJn6SprzYlk/BS4=
+github.com/skip-mev/slinky v0.2.1-0.20240205201114-084e56f076aa/go.mod h1:/ze8FaykAaF0wnxU9xtgzmoAYlTA1ibftejaG8mBzms=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -77,9 +77,9 @@ function edit_genesis() {
 	dasel put -t string -f "$GENESIS" '.genesis_time' -v "$GENESIS_TIME"
 
 	# Consensus params
-	dasel put -t string -f "$GENESIS" '.consensus_params.block.max_bytes' -v '4194304'
-	dasel put -t string -f "$GENESIS" '.consensus_params.block.max_gas' -v '-1'
-	dasel put -t string -f "$GENESIS" '.consensus_params.abci.vote_extensions_enable_height' -v '2'
+	dasel put -t string -f "$GENESIS" '.consensus.params.block.max_bytes' -v '4194304'
+	dasel put -t string -f "$GENESIS" '.consensus.params.block.max_gas' -v '-1'
+	dasel put -t string -f "$GENESIS" '.consensus.params.abci.vote_extensions_enable_height' -v '1'
 
 	# Update crisis module.
 	dasel put -t string -f "$GENESIS" '.app_state.crisis.constant_fee.denom' -v "$NATIVE_TOKEN"

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -79,6 +79,7 @@ function edit_genesis() {
 	# Consensus params
 	dasel put -t string -f "$GENESIS" '.consensus_params.block.max_bytes' -v '4194304'
 	dasel put -t string -f "$GENESIS" '.consensus_params.block.max_gas' -v '-1'
+	dasel put -t string -f "$GENESIS" '.consensus_params.abci.vote_extensions_enable_height' -v '2'
 
 	# Update crisis module.
 	dasel put -t string -f "$GENESIS" '.app_state.crisis.constant_fee.denom' -v "$NATIVE_TOKEN"

--- a/protocol/testing/testnet-local/local.sh
+++ b/protocol/testing/testnet-local/local.sh
@@ -95,6 +95,7 @@ create_validators() {
 		cat <<<"$new_file" >"$VAL_CONFIG_DIR"/node_key.json
 
 		edit_config "$VAL_CONFIG_DIR"
+    dasel put -t string -f "$VAL_CONFIG_DIR"/app.toml '.oracle.oracle_address' -v 'slinky0:8080'
 
 		# Using "*" as a subscript results in a single arg: "dydx1... dydx1... dydx1..."
 		# Using "@" as a subscript results in separate args: "dydx1..." "dydx1..." "dydx1..."
@@ -167,6 +168,12 @@ edit_config() {
 	dasel put -t string -f "$CONFIG_FOLDER"/config.toml '.consensus.timeout_commit' -v '5s'
 }
 
+
+edit_oracle_config() {
+  dasel put -t bool -f "/etc/oracle.toml" '.production' -v 'true'
+}
+
 install_prerequisites
 create_validators
 setup_cosmovisor
+edit_oracle_config


### PR DESCRIPTION
Adds Slinky's vote extensions to the chain.

Also updated the docker-compose and config handling so that `make localnet-start` successfully pulls prices from the slinky container and posts them to vote extensions. 

I did not hook anything up in the proposal handlers.